### PR TITLE
#141 Execute sparql for match with inferencing switched off, since it…

### DIFF
--- a/src/service/match/match.service.ts
+++ b/src/service/match/match.service.ts
@@ -173,7 +173,7 @@ export class MatchService {
                     sparqlQuery = this._generateSparqlQuery(id, name as string, type, limit || 25, propertyConditions);
                 }
 
-                const response = await this._artsdataService.executeSparqlQuery(sparqlQuery, true);
+                const response = await this._artsdataService.executeSparqlQuery(sparqlQuery, false);
                 const candidates = MatchServiceHelper.formatReconciliationResponse(requestLanguage,
                     response, reconciliationQuery, isQueryByURI);
                 results.push({candidates});


### PR DESCRIPTION
Execute SPARQL for matching with inference disabled, as it returns numerous explicit types.