### PR TITLE
feat(extend): include disambiguatingDescription for external source e…

### DIFF
--- a/src/constant/extend/query-by-graph.constants.ts
+++ b/src/constant/extend/query-by-graph.constants.ts
@@ -13,6 +13,7 @@ SELECT ?uri
   (SAMPLE(?wikidata_ids) AS ?wikidata_uri)
   (GROUP_CONCAT(DISTINCT ?types; SEPARATOR = ", ") AS ?type)
   (MAX(?flaggedForReview) AS ?is_flagged_for_review)
+  (SAMPLE(?disambiguating_description_val) AS ?disambiguating_description)
   <EXTRA_FIELD_SELECT_CLAUSE_QUERY_PLACEHOLDER>
 WHERE {
   GRAPH <GRAPH_URI_PLACEHOLDER> {
@@ -21,6 +22,10 @@ WHERE {
     OPTIONAL { ?uri schema:name ?name_no. FILTER(LANG(?name_no) = "") }
     BIND(COALESCE(?name_en, ?name_fr, ?name_no) AS ?name)
     FILTER(!ISBLANK(STR(?name)))
+    OPTIONAL { ?uri schema:disambiguatingDescription ?desc_en. FILTER(LANG(?desc_en) = "en") }
+    OPTIONAL { ?uri schema:disambiguatingDescription ?desc_fr. FILTER(LANG(?desc_fr) = "fr") }
+    OPTIONAL { ?uri schema:disambiguatingDescription ?desc_no. FILTER(LANG(?desc_no) = "") }
+    BIND(COALESCE(?desc_en, ?desc_fr, ?desc_no) AS ?disambiguating_description_val)
     ?uri a ?types.
     <FILTER_BY_REGION_PLACEHOLDER>
   }

--- a/src/constant/extend/query-by-graph.constants.ts
+++ b/src/constant/extend/query-by-graph.constants.ts
@@ -13,19 +13,21 @@ SELECT ?uri
   (SAMPLE(?wikidata_ids) AS ?wikidata_uri)
   (GROUP_CONCAT(DISTINCT ?types; SEPARATOR = ", ") AS ?type)
   (MAX(?flaggedForReview) AS ?is_flagged_for_review)
-  (SAMPLE(?disambiguating_description_val) AS ?disambiguating_description)
+  (SAMPLE(?disambiguating_descriptions) AS ?disambiguating_description)
   <EXTRA_FIELD_SELECT_CLAUSE_QUERY_PLACEHOLDER>
 WHERE {
   GRAPH <GRAPH_URI_PLACEHOLDER> {
     OPTIONAL { ?uri schema:name ?name_en. FILTER(LANG(?name_en) = "en") }
     OPTIONAL { ?uri schema:name ?name_fr. FILTER(LANG(?name_fr) = "fr") }
-    OPTIONAL { ?uri schema:name ?name_no. FILTER(LANG(?name_no) = "") }
-    BIND(COALESCE(?name_en, ?name_fr, ?name_no) AS ?name)
+    OPTIONAL { ?uri schema:name ?name_default. FILTER(LANG(?name_default) = "") }
+    OPTIONAL { ?uri schema:name ?name_mul. FILTER(LANG(?name_mul) = "mul") }
+    BIND(COALESCE(?name_en, ?name_fr, ?name_mul, ?name_default) AS ?name)
     FILTER(!ISBLANK(STR(?name)))
     OPTIONAL { ?uri schema:disambiguatingDescription ?desc_en. FILTER(LANG(?desc_en) = "en") }
     OPTIONAL { ?uri schema:disambiguatingDescription ?desc_fr. FILTER(LANG(?desc_fr) = "fr") }
-    OPTIONAL { ?uri schema:disambiguatingDescription ?desc_no. FILTER(LANG(?desc_no) = "") }
-    BIND(COALESCE(?desc_en, ?desc_fr, ?desc_no) AS ?disambiguating_description_val)
+    OPTIONAL { ?uri schema:disambiguatingDescription ?desc_default. FILTER(LANG(?desc_default) = "") }
+    OPTIONAL { ?uri schema:disambiguatingDescription ?desc_mul. FILTER(LANG(?desc_mul) = "mul") }
+    BIND(COALESCE(?desc_en, ?desc_fr,?desc_mul, ?desc_default) AS ?disambiguating_descriptions)
     ?uri a ?types.
     <FILTER_BY_REGION_PLACEHOLDER>
   }

--- a/src/service/extend/extend.service.ts
+++ b/src/service/extend/extend.service.ts
@@ -238,8 +238,9 @@ export class ExtendService {
                    ?uri schema:performer ?performer .
                    OPTIONAL { ?performer schema:name   ?performer_name_en. FILTER( LANG(?performer_name_en) = "en")}
                    OPTIONAL { ?performer schema:name  ?performer_name_fr. FILTER( LANG(?performer_name_fr) = "fr")}
-                   OPTIONAL { ?performer schema:name  ?performer_name_no. FILTER ( LANG(?performer_name_no) = "")}
-                  BIND(COALESCE(?performer_name_en, ?performer_name_fr, ?performer_name_no) as ?performerName)
+                   OPTIONAL { ?performer schema:name  ?performer_name_default. FILTER ( LANG(?performer_name_default) = "")}
+                   OPTIONAL { ?performer schema:name  ?performer_name_mul. FILTER ( LANG(?performer_name_mul) = "mul")}
+                  BIND(COALESCE(?performer_name_en, ?performer_name_fr, ?performer_name_mul, ?performer_name_default) as ?performerName)
               }
             #Offer buy uri
             OPTIONAL { ?uri schema:offers/schema:url ?offer_url }


### PR DESCRIPTION
This pull request updates the SPARQL query in `query-by-graph.constants.ts` to add support for retrieving a `disambiguating_description` field in multiple languages. The main changes ensure that the best available description is selected and included in the query results.

**Enhancements to SPARQL query fields:**

* Added a new field to the SELECT clause to return a sample value for `disambiguating_description` (`disambiguating_description`).

**Multilingual support for disambiguating descriptions:**

* Added OPTIONAL clauses to retrieve `schema:disambiguatingDescription` in English, French, and the default language, and used `COALESCE` to select the first available value as `disambiguating_description_val`.…ntities