### PR TITLE
Populate wikidata_uri for Wikidata-source graphs

### DIFF
--- a/src/constant/extend/query-by-graph.constants.ts
+++ b/src/constant/extend/query-by-graph.constants.ts
@@ -10,7 +10,7 @@ SELECT ?uri
   (SAMPLE(?name) AS ?name)
   (SAMPLE(?isni_uris) AS ?isni_uri)
   (COALESCE(SAMPLE(?adids), SAMPLE(?adid_obj)) AS ?artsdata_uri)
-  (SAMPLE(?wikidata_ids) AS ?wikidata_uri)
+  (COALESCE(SAMPLE(?wikidata_ids), SAMPLE(?wikidata_self)) AS ?wikidata_uri)
   (GROUP_CONCAT(DISTINCT ?types; SEPARATOR = ", ") AS ?type)
   (MAX(?flaggedForReview) AS ?is_flagged_for_review)
   <EXTRA_FIELD_SELECT_CLAUSE_QUERY_PLACEHOLDER>
@@ -43,6 +43,10 @@ WHERE {
   OPTIONAL { 
     ?uri schema:sameAs ?wikidata_ids. 
     FILTER(STRSTARTS(STR(?wikidata_ids), "http://www.wikidata.org/entity/")) 
+  }
+  OPTIONAL { 
+    FILTER(STRSTARTS(STR(?uri), "http://www.wikidata.org/entity/")) 
+    BIND(?uri AS ?wikidata_self) 
   }
   OPTIONAL { 
     ?uri schema:sameAs ?isni_uris. 

--- a/src/service/extend/extend.service.spec.ts
+++ b/src/service/extend/extend.service.spec.ts
@@ -109,6 +109,46 @@ describe('ExtendService', () => {
                 },
             ]);
         });
+
+        it('return wikidata id is the entity URI itself is wikidata URI', async () => {
+            artsdataService.executeSparqlQuery.mockResolvedValueOnce({
+                "results": {
+                    "bindings": [
+                        {
+                            "uri": {
+                                "type": "uri",
+                                "value": "http://www.wikidata.org/entity/123"
+                            },
+                            "name": {
+                                "xml:lang": "en",
+                                "type": "literal",
+                                "value": "Entity Name"
+                            },
+                            "wikidata_uri": {
+                                "type": "uri",
+                                "value": "http://www.wikidata.org/entity/123"
+                            },
+                            "type": {
+                                "type": "literal",
+                                "value": "http://schema.org/Person"
+                            }
+                        }]
+                }
+            });
+
+            const result = await extendService.getExtendDataFromGraph(
+                'https://kg.artsdata.ca/culture-creates/graph', EntityClassEnum.PERSON, "");
+
+            expect(result).toEqual([
+                {
+                    name: 'Entity Name',
+                    uri: 'http://www.wikidata.org/entity/123',
+                    wikidata_uri: 'http://www.wikidata.org/entity/123',
+                    reconciled: false,
+                    type: 'http://schema.org/Person',
+                },
+            ]);
+        });
     });
 });
 


### PR DESCRIPTION
This pull request updates the SPARQL query logic in `query-by-graph.constants.ts` to improve how Wikidata URIs are selected. The key change ensures that if an entity's own URI is a Wikidata entity, it is used as the `wikidata_uri` when no explicit `schema:sameAs` Wikidata link exists.

**Improvements to Wikidata URI selection:**

* The `SELECT` clause now uses `COALESCE(SAMPLE(?wikidata_ids), SAMPLE(?wikidata_self))` for the `wikidata_uri` field, allowing fallback to the entity's own URI if it is a Wikidata entity.
* Added a new `OPTIONAL` block in the `WHERE` clause to bind the entity's own URI to `?wikidata_self` if it is a Wikidata entity, enabling the fallback logic.